### PR TITLE
File with id "XXXXXXX" page loading failed fix

### DIFF
--- a/bin/utils/goTo.ts
+++ b/bin/utils/goTo.ts
@@ -6,8 +6,6 @@ const goTo = async (page: Page, targetURL: string) => {
 
   await page.goto(targetURL);
   await waitForRedirects(page, { timeout: 5000 });
-
-  if (!page.url().includes(targetURL)) throw new Error(`Page loading failed.`);
 };
 
 export default goTo;


### PR DESCRIPTION
The problem seems to be that Figma is doing multiple redirects so the assumption that page.url() includes targetURL is not true anymore

fixes #29 